### PR TITLE
items/showでの画像の表示

### DIFF
--- a/app/assets/stylesheets/modules/_top-page.scss
+++ b/app/assets/stylesheets/modules/_top-page.scss
@@ -1439,7 +1439,6 @@ element.style {
   }
 
   .slick-dots {
-    opacity: .4;
     width: 300px;
     height: 300px;
     margin-bottom: -95px;
@@ -1448,7 +1447,13 @@ element.style {
       height: 60px;
     }
     li {
+      opacity: .4;
+      width: 60px;
+      height: 60px;
       bottom: -180px;
+    }
+    .slick-active{
+      opacity:1;
     }
   }
 }


### PR DESCRIPTION
# what
- items/showにてslickで実装していた画像一覧のactiveのもののopacityを.4 =>1に変更

# why
- activeになっているかどうかわからない